### PR TITLE
add platforms information to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "ed25519swift",
+    platforms: [
+        .macOS(.v10_12), .iOS("11.4")
+    ],
     products: [
         .library(
             name: "ed25519swift",


### PR DESCRIPTION
I'm adding `platforms` property to Package.swift file based on the podspec file.
This also fixes build issue on XCode 11 for projects that have ed25519swift as a dependency and get this kind of error:
`...requires minimum platform version 9.0 for the iOS platform, but this target supports 8.0 (in target 'ed25519swift' from project 'ed25519swift')`