### PR TITLE
Fixing Package.swift

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ import PackageDescription
 let package = Package(
     name: "ed25519swift",
     platforms: [
-        .macOS(.v10_12), .iOS("11.4")
+        .macOS(.v10_14),
+        .iOS(.v12)
     ],
     products: [
         .library(


### PR DESCRIPTION
I'm not sure how this was even working to be honest. I changed it to use proper enums and I also change the version number because I was getting

```bash
error: the library 'ed25519swift' requires macos 10.10, but depends on the product 'CryptoSwift' which requires macos 10.12; consider changing the library 'ed25519swift' to require macos 10.12 or later, or the product 'CryptoSwift' to require macos 10.10 or earlier.
```

This seems to have fixed it.